### PR TITLE
#3: Preserve time column type instead of using datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Before running the migration script, ensure you have the following setup:
 The migration script provides comprehensive SQLite to MySQL/MariaDB migration with the following capabilities:
 
 - **Smart Type Mapping**: Automatically converts SQLite data types to appropriate MySQL equivalents
+  - Correctly maps `TIME` columns to MySQL `TIME` (not `DATETIME`)
+  - Handles `DATE`, `DATETIME`, and `TIMESTAMP` appropriately
 - **Reserved Word Handling**: Escapes MySQL reserved keywords (like `group`, `order`, `key`) with backticks
 - **Index Compatibility**: Handles MySQL's 767-byte index limit by adjusting VARCHAR lengths for indexed columns
 - **Foreign Key Management**: Temporarily disables foreign key checks during migration
@@ -170,4 +172,6 @@ For migrating Uptime Kuma from SQLite3 to MariaDB, follow these steps carefully:
 
 This script handles several quirks specific to the migration:
 - **Reserved Keywords**: Tables named `group` (MariaDB won't allow as it's a reserved keyword, but the script circumvents this with escape characters)
+- **TIME vs DATETIME Mapping**: Correctly preserves `TIME` columns (like `start_time`/`end_time` in `maintenance` table) as `TIME` in MySQL instead of incorrectly converting to `DATETIME`
+- **Index Length Limitations**: Handles MySQL's 767-byte index key length limit by adjusting VARCHAR sizes for indexed columns
 - Other edge cases are handled automatically by the script

--- a/migrate.py
+++ b/migrate.py
@@ -64,10 +64,13 @@ def map_sqlite_to_mysql_type(sqlite_type_raw, is_primary_key=False, is_unique=Fa
         return "DECIMAL(10,2)"
     elif "BOOL" in sqlite_type:
         return "TINYINT(1)"
-    elif "DATE" in sqlite_type or "TIME" in sqlite_type:
-        # In older MySQL, DATETIME doesn't support CURRENT_TIMESTAMP default.
-        # We'll use DATETIME and have the app populate 'created_at'.
-        # 'updated_at' will use TIMESTAMP with ON UPDATE.
+    elif sqlite_type == "TIME":
+        # Handle TIME type specifically - should remain TIME in MySQL
+        # This fixes the issue where start_time/end_time in maintenance table
+        # were incorrectly converted to DATETIME instead of TIME
+        return "TIME"
+    elif "DATE" in sqlite_type:
+        # Handle DATE and DATETIME types - both map to DATETIME in MySQL
         return "DATETIME"
     else:
         print(f"Warning: Unknown SQLite type '{sqlite_type_raw}'. Defaulting to VARCHAR(255).")


### PR DESCRIPTION
- # Fixes #3 
- Preserve `TIME` column type instead of using `DATETIME`