### PR TITLE
#9: Make collation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Before running the migration script, ensure you have the following setup:
        'host': 'localhost',           # MySQL server host
        'user': 'kuma_user',          # Database user
        'password': 'your_secure_password',  # User password
-       'database': 'mysqldatabase'            # Target database name
+       'database': 'mysqldatabase',            # Target database name
+       # 'collation': 'utf8mb4_uca1400_ai_ci' # Optional: override collation (default: utf8mb4_unicode_ci)
    }
    ```
 
@@ -46,6 +47,8 @@ Before running the migration script, ensure you have the following setup:
 
 The migration script provides comprehensive SQLite to MySQL/MariaDB migration with the following capabilities:
 
+- **Configurable Collation**: Supports custom collations via the `collation` configuration option (default: `utf8mb4_unicode_ci`)
+  - Solves errors like `1273 (HY000): Unknown collation` on newer MariaDB versions
 - **Smart Type Mapping**: Automatically converts SQLite data types to appropriate MySQL equivalents
   - Correctly maps `TIME` columns to MySQL `TIME` (not `DATETIME`)
   - Handles `DATE`, `DATETIME`, and `TIMESTAMP` appropriately
@@ -174,6 +177,7 @@ For migrating Uptime Kuma from SQLite3 to MariaDB, follow these steps carefully:
 ### Known Quirks Handled
 
 This script handles several quirks specific to the migration:
+- **Collation Compatibility**: Allows overriding the connection and table collation to resolve compatibility issues (e.g., using `utf8mb4_uca1400_ai_ci` on newer MariaDB or `utf8mb4_general_ci` on older systems)
 - **Reserved Keywords**: Tables named `group` (MariaDB won't allow as it's a reserved keyword, but the script circumvents this with escape characters)
 - **TIME vs DATETIME Mapping**: Correctly preserves `TIME` columns (like `start_time`/`end_time` in `maintenance` table) as `TIME` in MySQL instead of incorrectly converting to `DATETIME`
 - **Index Length Limitations**: Handles MySQL's 767-byte index key length limit by adjusting VARCHAR sizes for indexed columns

--- a/migrate.py
+++ b/migrate.py
@@ -131,6 +131,11 @@ def migrate_sqlite_to_mysql(sqlite_db_path, mysql_config):
 
     # Detect server type (MySQL vs MariaDB)
     is_mysql = is_mysql_server(mysql_cursor)
+    
+    # Determined collation to use for CREATE TABLE
+    # Default to utf8mb4_unicode_ci if not specified in config
+    db_collation = mysql_config.get('collation', 'utf8mb4_unicode_ci')
+    print(f"Using collation: {db_collation}")
 
     try:
         mysql_cursor.execute("SET FOREIGN_KEY_CHECKS = 0;")
@@ -305,7 +310,7 @@ def migrate_sqlite_to_mysql(sqlite_db_path, mysql_config):
             # create_stmt = f"CREATE TABLE IF NOT EXISTS `{table_name}` (\n    {joined_col_defs}\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;"
             
             # The most compatible CREATE TABLE statement based on our troubleshooting
-            create_stmt = f"CREATE TABLE IF NOT EXISTS {escaped_table_name} (\n    {joined_col_defs}\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"
+            create_stmt = f"CREATE TABLE IF NOT EXISTS {escaped_table_name} (\n    {joined_col_defs}\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE={db_collation};"
 
             print(f"Generated CREATE TABLE statement:\n{create_stmt}")
 
@@ -419,6 +424,7 @@ mysql_connection_config = {
     'user': 'mysqluser', ## database user
     'password': 'changeme', ### password
     'database': 'mysqldatabase' ## database name
+    # 'collation': 'utf8mb4_uca1400_ai_ci' ## Optional: override collation (default: utf8mb4_unicode_ci)
 }
 
 # --- Run the migration ---

--- a/tests/create_test_db.py
+++ b/tests/create_test_db.py
@@ -259,7 +259,7 @@ def create_test_database(db_path='kuma.db'):
     conn.commit()
     conn.close()
     
-    print(f"\n✅ Test database created successfully: {db_path}")
+    print(f"\nTest database created successfully: {db_path}")
     print("\nDatabase statistics:")
     
     # Reopen to show statistics
@@ -279,4 +279,4 @@ def create_test_database(db_path='kuma.db'):
 
 if __name__ == "__main__":
     create_test_database()
-    print("\n✅ Ready to run migration with: python migrate.py")
+    print("\nReady to run migration with: python migrate.py")

--- a/tests/test_collation.py
+++ b/tests/test_collation.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Test specifically for Collation handling using Mocking.
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add parent directory to path to import migrate
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from migrate import migrate_sqlite_to_mysql
+import sqlite3
+
+class TestCollation(unittest.TestCase):
+    def setUp(self):
+        # Create a simple SQLite DB
+        self.sqlite_db = 'test_collation.db'
+        if os.path.exists(self.sqlite_db):
+            os.remove(self.sqlite_db)
+            
+        conn = sqlite3.connect(self.sqlite_db)
+        cursor = conn.cursor()
+        cursor.execute("CREATE TABLE test_col (id INTEGER PRIMARY KEY, val TEXT)")
+        cursor.execute("INSERT INTO test_col VALUES (1, 'abc')")
+        conn.commit()
+        conn.close()
+
+        self.mysql_config = {
+            'host': 'localhost',
+            'user': 'root',
+            'password': '',
+            'database': 'test_db',
+            # We will set 'collation' in the test methods
+        }
+
+    def tearDown(self):
+        if os.path.exists(self.sqlite_db):
+            os.remove(self.sqlite_db)
+
+    @patch('mysql.connector.connect')
+    def test_custom_collation(self, mock_connect):
+        # Setup the mock
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connect.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+
+        # Set specific collation
+        target_collation = 'utf8mb4_uca1400_ai_ci'
+        self.mysql_config['collation'] = target_collation
+        
+        migrate_sqlite_to_mysql(self.sqlite_db, self.mysql_config)
+
+        # Check all execute calls to find the CREATE TABLE statement
+        create_stmt_found = False
+        for call in mock_cursor.execute.call_args_list:
+            args, _ = call
+            sql = args[0]
+            if "CREATE TABLE IF NOT EXISTS `test_col`" in sql:
+                if f"COLLATE={target_collation}" in sql:
+                    create_stmt_found = True
+        
+        self.assertTrue(create_stmt_found, f"CREATE TABLE statement with COLLATE={target_collation} not found in executed queries.")
+
+    @patch('mysql.connector.connect')
+    def test_default_collation(self, mock_connect):
+        # Setup the mock
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connect.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+
+        # Remove collation key (default behavior)
+        if 'collation' in self.mysql_config:
+            del self.mysql_config['collation']
+            
+        migrate_sqlite_to_mysql(self.sqlite_db, self.mysql_config)
+
+        # Check all execute calls to find the CREATE TABLE statement
+        create_stmt_found = False
+        expected_default = 'utf8mb4_unicode_ci'
+        
+        for call in mock_cursor.execute.call_args_list:
+            args, _ = call
+            sql = args[0]
+            if "CREATE TABLE IF NOT EXISTS `test_col`" in sql:
+                if f"COLLATE={expected_default}" in sql:
+                    create_stmt_found = True
+        
+        self.assertTrue(create_stmt_found, f"CREATE TABLE statement with default COLLATE={expected_default} not found.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_longtext_default.py
+++ b/tests/test_longtext_default.py
@@ -91,7 +91,7 @@ def create_test_db_with_text_defaults():
     conn.commit()
     conn.close()
     
-    print(f"\n✅ Test database created: {db_path}")
+    print(f"\nTest database created: {db_path}")
     
     # Show statistics
     conn = sqlite3.connect(db_path)
@@ -142,10 +142,10 @@ def run_migration_test(sqlite_db_path):
     # Run migration
     try:
         migrate_sqlite_to_mysql(sqlite_db_path, mysql_config)
-        print("\n✅ Migration completed")
+        print("\nMigration completed")
         return True
     except Exception as e:
-        print(f"\n❌ Migration failed: {e}")
+        print(f"\nMigration failed: {e}")
         return False
 
 def verify_mysql_schema():
@@ -201,11 +201,11 @@ def verify_mysql_schema():
                 if is_text_blob:
                     if default is not None and default != 'NULL':
                         # This is an ERROR on MySQL
-                        msg = f"  ❌ PROBLEM: `{col_name}` ({col_type}) has DEFAULT '{default}'"
+                        msg = f"  PROBLEM: `{col_name}` ({col_type}) has DEFAULT '{default}'"
                         print(msg)
                         issues_found.append(f"{table}.{col_name}: {col_type} with DEFAULT {default}")
                     else:
-                        msg = f"  ✅ CORRECT: `{col_name}` ({col_type}) has no DEFAULT"
+                        msg = f"  CORRECT: `{col_name}` ({col_type}) has no DEFAULT"
                         print(msg)
                         successes.append(f"{table}.{col_name}: {col_type}")
                 elif default is not None:
@@ -216,17 +216,17 @@ def verify_mysql_schema():
         print("="*80)
         print("SUMMARY")
         print("="*80)
-        print(f"\n✅ Correct TEXT/BLOB columns (no DEFAULT): {len(successes)}")
+        print(f"\nCorrect TEXT/BLOB columns (no DEFAULT): {len(successes)}")
         for s in successes:
             print(f"   - {s}")
         
         if issues_found:
-            print(f"\n❌ Problematic TEXT/BLOB columns (has DEFAULT): {len(issues_found)}")
+            print(f"\nProblematic TEXT/BLOB columns (has DEFAULT): {len(issues_found)}")
             for issue in issues_found:
                 print(f"   - {issue}")
-            print("\n⚠️  These DEFAULT values will cause Error 1101 on MySQL!")
+            print("\nThese DEFAULT values will cause Error 1101 on MySQL!")
         else:
-            print("\n✅ No issues found! All TEXT/BLOB columns correctly have no DEFAULT values on MySQL.")
+            print("\nNo issues found! All TEXT/BLOB columns correctly have no DEFAULT values on MySQL.")
         
         # Test data integrity
         print("\n" + "="*80)
@@ -259,7 +259,7 @@ def verify_mysql_schema():
         return len(issues_found) == 0
         
     except mysql.connector.Error as e:
-        print(f"❌ Error verifying MySQL schema: {e}")
+        print(f"Error verifying MySQL schema: {e}")
         return False
 
 if __name__ == "__main__":
@@ -277,11 +277,11 @@ if __name__ == "__main__":
         
         if success:
             print("\n" + "="*80)
-            print("✅ TEST PASSED: LONGTEXT columns correctly have no DEFAULT on MySQL")
+            print("TEST PASSED: LONGTEXT columns correctly have no DEFAULT on MySQL")
             print("="*80)
         else:
             print("\n" + "="*80)
-            print("❌ TEST FAILED: Some LONGTEXT columns incorrectly have DEFAULT values")
+            print("TEST FAILED: Some LONGTEXT columns incorrectly have DEFAULT values")
             print("="*80)
     else:
-        print("\n❌ Migration failed, cannot verify schema")
+        print("\nMigration failed, cannot verify schema")

--- a/tests/verify_migration.py
+++ b/tests/verify_migration.py
@@ -17,13 +17,13 @@ def verify_migration(mysql_config):
     try:
         conn = mysql.connector.connect(**mysql_config)
         cursor = conn.cursor()
-        print(f"✅ Connected to MySQL database: {mysql_config['database']}")
+        print(f"Connected to MySQL database: {mysql_config['database']}")
         print("=" * 80)
         
         # Get list of tables
         cursor.execute("SHOW TABLES")
         tables = [table[0] for table in cursor.fetchall()]
-        print(f"\n📊 Found {len(tables)} tables in MySQL:")
+        print(f"\nFound {len(tables)} tables in MySQL:")
         print(f"   {', '.join(tables)}\n")
         
         # Verify each table
@@ -33,10 +33,10 @@ def verify_migration(mysql_config):
             'status_page', 'metrics'
         ]
         
-        print("🔍 Verifying tables:\n")
+        print("Verifying tables:\n")
         for table in expected_tables:
             if table not in tables:
-                print(f"   ❌ Table '{table}' is MISSING!")
+                print(f"   Table '{table}' is MISSING!")
                 continue
             
             # Get row count
@@ -47,7 +47,7 @@ def verify_migration(mysql_config):
             cursor.execute(f"DESCRIBE `{table}`")
             columns = cursor.fetchall()
             
-            print(f"   ✅ Table: `{table}`")
+            print(f"   Table: `{table}`")
             print(f"      - Rows: {count}")
             print(f"      - Columns: {len(columns)}")
             
@@ -64,7 +64,7 @@ def verify_migration(mysql_config):
         
         # Detailed verification of edge cases
         print("=" * 80)
-        print("\n🔬 Detailed Edge Case Verification:\n")
+        print("\nDetailed Edge Case Verification:\n")
         
         # 1. Check TIME data type in maintenance table
         print("1. TIME Data Type (maintenance table):")
@@ -138,16 +138,16 @@ def verify_migration(mysql_config):
             print(f"   - {row[0]}: {row[1]}...")
         
         print("\n" + "=" * 80)
-        print("✅ MIGRATION VERIFICATION COMPLETE!")
+        print("MIGRATION VERIFICATION COMPLETE!")
         print("=" * 80)
         
         cursor.close()
         conn.close()
         
     except Error as e:
-        print(f"❌ Error connecting to MySQL: {e}")
+        print(f"Error connecting to MySQL: {e}")
     except Exception as e:
-        print(f"❌ Unexpected error: {e}")
+        print(f"Unexpected error: {e}")
 
 if __name__ == "__main__":
     mysql_config = {


### PR DESCRIPTION
- Make collation configurable part of `mysql_connection_config`
- Defaults to `utf8mb4_unicode_ci`, on older versions of mariadb `utf8mb4_general_ci` could be set & newer versions `utf8mb4_uca1400_ai_ci`